### PR TITLE
exit 実装

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -15,7 +15,7 @@ typedef struct s_kvs {
 typedef struct s_context
 {
 	t_kvs	*environ;
-	int		exit_status;
+	unsigned char	exit_status;
 	bool	flg_heredoc_expand;
 }	t_context;
 

--- a/srcs/built_exit.c
+++ b/srcs/built_exit.c
@@ -18,6 +18,8 @@ bool	is_numeric(char *argv)
 	int	i;
 
 	i = 0;
+	if (argv[i] == '+' || argv[i] == '-')
+		i++;
 	while (argv[i])
 	{
 		if (!(ft_isdigit(argv[i])))
@@ -27,22 +29,53 @@ bool	is_numeric(char *argv)
 	return (true);
 }
 
+bool	is_greater_than_LONG_MAX(t_node *parsed_tokens)
+{
+	long	ret;
+	int	i;
+	int		sign;
+
+	ret = 0;
+	i = 0;
+	sign = 1;
+	if (parsed_tokens->argv[1][i] == '+' || parsed_tokens->argv[1][i] == '-')
+	{
+		if (parsed_tokens->argv[1][i] == '-')
+			sign = -1;
+		i++;
+	}
+	while (parsed_tokens->argv[1][i])
+	{
+		if ((ret > LONG_MAX / 10) || (ret == LONG_MAX / 10 && parsed_tokens->argv[1][i] > '7'))
+			return (true);
+		else if ((ret < LONG_MIN / 10) || (ret == LONG_MIN / 10 && parsed_tokens->argv[1][i] > '8'))
+			return (true);
+		ret = ret * 10 + (parsed_tokens->argv[1][i] - '0') * sign;
+		i++;
+	}
+	return (false);
+}
+
 bool	built_exit(t_node *parsed_tokens, char **path_list, t_context *context, t_exe_info *info)
 {
 	ft_printf("exit\n");
-	if (!(is_numeric(parsed_tokens->argv[1]))) // && LONG_MAX より大きければ
+	// 引数のひとつめが数字以外
+	if ((!(is_numeric(parsed_tokens->argv[1]))) || is_greater_than_LONG_MAX(parsed_tokens))
 	{
-		printf("bash: exit: %s: numeric argument required\n", parsed_tokens->argv[1]);
+		ft_printf("bash: exit: %s: numeric argument required\n", parsed_tokens->argv[1]);
 		context->exit_status = 2;
 	}
-	else if (parsed_tokens->argv[1] != NULL)
+	// 引数の２つ目が存在しない
+	else if (parsed_tokens->argv[2] != NULL)
 	{
 		context->exit_status = EXIT_FAILURE;
 		ft_printf("bash: exit: too many arguments\n");
 		return (EXIT_FAILURE);
 	}
+	context->exit_status = ft_atol(parsed_tokens->argv[1]);
 	reset_fd(info);
 	free_after_invoke(path_list, parsed_tokens, info);
 	free_context(context);
-    exit(EXIT_SUCCESS);
+	exit(EXIT_SUCCESS);
 }
+

--- a/srcs/built_exit.c
+++ b/srcs/built_exit.c
@@ -6,16 +6,41 @@
 /*   By: yehara <yehara@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/23 17:40:48 by yehara            #+#    #+#             */
-/*   Updated: 2025/02/23 17:41:14 by yehara           ###   ########.fr       */
+/*   Updated: 2025/02/26 02:33:59 by yehara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <builtin.h>
 #include <utils.h>
 
+bool	is_numeric(char *argv)
+{
+	int	i;
+
+	i = 0;
+	while (argv[i])
+	{
+		if (!(ft_isdigit(argv[i])))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
 bool	built_exit(t_node *parsed_tokens, char **path_list, t_context *context, t_exe_info *info)
 {
-    ft_printf("exit\n");
+	ft_printf("exit\n");
+	if (!(is_numeric(parsed_tokens->argv[1]))) // && LONG_MAX より大きければ
+	{
+		printf("bash: exit: %s: numeric argument required\n", parsed_tokens->argv[1]);
+		context->exit_status = 2;
+	}
+	else if (parsed_tokens->argv[1] != NULL)
+	{
+		context->exit_status = EXIT_FAILURE;
+		ft_printf("bash: exit: too many arguments\n");
+		return (EXIT_FAILURE);
+	}
 	reset_fd(info);
 	free_after_invoke(path_list, parsed_tokens, info);
 	free_context(context);


### PR DESCRIPTION
# exit のエラーメッセージについて
終了ステータスは 255 が最大で負の数になることはない。
unsigned char 型でもつ
- 引数が複数ある
終了ステータスは1でexitしない
Bash yehara $ exit 0 1 2
exit
bash: exit: too many arguments
Bash yehara $ exit a

- 数字以外
終了ステータスは2でexitする
exit
bash: exit: a: numeric argument required

- LONG_MAX 以上の数字
LONG_MAX まではエラーメッセージを表示しない
終了ステータスは2でexitする
Bash yehara $ exit 9223372036854775808
exit
bash: exit: 9223372036854775808: numeric argument required

- 引数が負の値のとき
数字に変換して exit_status に代入するだけで良さそう
Bash yehara $ exit -2
exit
yehara % echo $?
254

- 符号がある場合
連続してたら文字扱い、ひとつなら数字として扱う
Bash yehara $ exit --1
exit
bash: exit: --1: numeric argument required
Bash yehara $ exit -1
exit
