### PR TITLE
unset のエラー処理追加

### DIFF
--- a/srcs/built_echo.c
+++ b/srcs/built_echo.c
@@ -73,7 +73,7 @@ bool	built_echo(const t_node *parsed_tokens, t_context *context)
 
 	// はじめのオプションのみ検証する
 	if (parsed_tokens->argv[1] == NULL)
-		return (ft_printf("\n"), EXIT_SUCCESS);
+		return (ft_printf("\n"), setting_exit_status(context, EXIT_SUCCESS));
 	flg_option = has_option(parsed_tokens->argv[1]);
 	message = create_message(parsed_tokens->argv, flg_option);
 	if (flg_option)
@@ -81,6 +81,5 @@ bool	built_echo(const t_node *parsed_tokens, t_context *context)
 	else
 		ft_printf("%s\n", message);
 	free(message);
-	context->exit_status = EXIT_SUCCESS;
-	return (context->exit_status);
+	return (setting_exit_status(context, EXIT_SUCCESS));
 }

--- a/srcs/built_env.c
+++ b/srcs/built_env.c
@@ -24,5 +24,5 @@ bool	built_env(t_context *context)
 				context->environ[i].key, context->environ[i].value);
 		i++;
 	}
-	return (EXIT_SUCCESS);
+	return (setting_exit_status(context, EXIT_SUCCESS));
 }

--- a/srcs/built_export.c
+++ b/srcs/built_export.c
@@ -90,5 +90,6 @@ bool	built_export(const t_node *parsed_tokens, t_context *context)
 		sorted_print(context);
 	else
 		update_env(parsed_tokens, context);
-	return (EXIT_SUCCESS);
+	return (setting_exit_status(context, EXIT_SUCCESS));
 }
+

--- a/srcs/built_unset.c
+++ b/srcs/built_unset.c
@@ -12,12 +12,38 @@
 
 #include "builtin.h"
 
+bool	is_variable(char *argv)
+{
+	int	i;
+
+	i = 0;
+	if (ft_isdigit(argv[i]))
+		return (false);
+	while (argv[i])
+	{
+		if (!(ft_isalnum(argv[i]) || argv[i] == '_'))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
 bool	built_unset(const	t_node *parsed_tokens, t_context *context)
 {
 	int	i;
 
 	i = 1;
 	while (parsed_tokens->argv[i])
-		xunsetenv(parsed_tokens->argv[i++], context);
-	return (EXIT_SUCCESS);
+	{
+		if (is_variable(parsed_tokens->argv[i]))
+			xunsetenv(parsed_tokens->argv[i], context);
+		else
+		{
+			ft_printf("minishell: unset: `%s': not a valid identifier\n", parsed_tokens->argv[i]);
+			return (setting_exit_status(context, EXIT_FAILURE));
+		}
+		i++;
+	}
+	return (setting_exit_status(context, EXIT_SUCCESS));
 }
+


### PR DESCRIPTION
Bash 変数で使用できない文字はエラーを返す
変数の定義
- 数字、アルファベット、_ のみ使用できる
- 数字で始まらない