### PR TITLE
expand のノームエラーを修正

### DIFF
--- a/includes/units/expand.h
+++ b/includes/units/expand.h
@@ -19,13 +19,18 @@ typedef struct s_token		t_token;
 typedef struct s_context	t_context;
 typedef struct s_kvs		t_kvs;
 
+typedef struct s_expand {
+	t_context *context;
+	char	*token;
+} t_expand;
+
 t_token	*expand_tokens(t_token **_tokens, t_context *context);
 
 // expand_utils
 char	*search_env(const char *key, t_kvs *environ);
 size_t	insert_env(char **buffer, char *token, t_context *context);
-size_t	expand_variable(char **result, char *token, t_context *context,
-		int start, int i);
+size_t	expand_variable(char **result, t_expand expand, int start, int i);
 bool	is_expand(char *token, int i);
+void	set_flg_heredoc_expand(t_token *token, t_context *context);
 
 #endif

--- a/srcs/expand_tokens.c
+++ b/srcs/expand_tokens.c
@@ -25,37 +25,36 @@ static size_t	delete_single_quote(char **result, char *token)
 	return (i + 1);
 }
 
-static size_t	expand_double_quote(char **result, char *token, bool flg_heredoc, t_context *context)
+static size_t	expand_double_quote(char **result, t_expand expand, bool flg_heredoc)
 {
 	int	i;
 	int		start;
 
 	i = 1;
 	start = 1;
-	while (token[i] != DOUBLE_QUOTE)
+	while (expand.token[i] != DOUBLE_QUOTE)
 	{
-		if (is_expand(token, i) && !flg_heredoc)
+		if (is_expand(expand.token, i) && !flg_heredoc)
 		{
-			*result = free_strjoin(*result, ft_substr(token, start, i - start));
-			i += insert_env(result, &token[i], context);
+			*result = free_strjoin(*result, ft_substr(expand.token, start, i - start));
+			i += insert_env(result, &expand.token[i], expand.context);
 			// 「"」と「$」のため、i+1
 			start = i + 1;
 		}
 		i++;
 	}
-	*result = free_strjoin(*result, ft_substr(token, start, i - start));
+	*result = free_strjoin(*result, ft_substr(expand.token, start, i - start));
 	return (i + 1);
 }
 
-size_t	expand_variable(char **result, char *token, t_context *context,
-		int start, int i)
+size_t	expand_variable(char **result, t_expand expand, int start, int i)
 {
-	*result = free_strjoin(*result, ft_substr(token, start, i - start));
-	i += insert_env(result, &token[i], context);
+	*result = free_strjoin(*result, ft_substr(expand.token, start, i - start));
+	i += insert_env(result, &expand.token[i], expand.context);
 	return (i + 1);
 }
 
-static char	*expand_token(char *token, bool flg_heredoc, t_context *context)
+static char	*expand_token(t_expand expand, bool flg_heredoc)
 {
 	int		i;
 	char	*result;
@@ -64,32 +63,25 @@ static char	*expand_token(char *token, bool flg_heredoc, t_context *context)
 	i = 0;
 	start = 0;
 	result = ft_strdup("");
-	while (token[i])
+	while (expand.token[i])
 	{
-		if (token[i] == SINGLE_QUOTE)
-			i = delete_single_quote(&result, &token[i]);
-		else if (token[i] == DOUBLE_QUOTE)
-			i = expand_double_quote(&result, &token[i], flg_heredoc, context);
-		else if (is_expand(token, i) && !flg_heredoc)
-			i = expand_variable(&result, token, context, start, i);
+		if (expand.token[i] == SINGLE_QUOTE)
+			i = delete_single_quote(&result, &expand.token[i]);
+		else if (expand.token[i] == DOUBLE_QUOTE)
+			i = expand_double_quote(&result, expand, flg_heredoc);
+		else if (is_expand(expand.token, i) && !flg_heredoc)
+			i = expand_variable(&result, expand, start, i);
 		else
 		{
-			i++;
-			if (is_quote(token[i]))
-				result = free_strjoin(result, ft_substr(token, start, i - start));
+			if (is_quote(expand.token[i++]))
+				result = free_strjoin(result, ft_substr(expand.token, start, i - start));
 			// 変数展開したときのみ、start を更新したいため、continue する
 			continue ;
 		}
 		start = i;
 	}
-	result = free_strjoin(result, ft_substr(token, start, i - start));
+	result = free_strjoin(result, ft_substr(expand.token, start, i - start));
 	return (result);
-}
-
-static void	set_flg_heredoc_expand(t_token *token, t_context *context)
-{
-	if (ft_strchr(token->data, SINGLE_QUOTE) != NULL || ft_strchr(token->data, DOUBLE_QUOTE) != NULL)
-		context->flg_heredoc_expand = false;
 }
 
 t_token	*expand_tokens(t_token **_tokens, t_context *context)
@@ -98,10 +90,12 @@ t_token	*expand_tokens(t_token **_tokens, t_context *context)
 	t_token	*tokens;
     char    *temp;
 	bool	flg_heredoc;
+	t_expand expand;
 
 	flg_heredoc = false;
 	head = *_tokens;
 	tokens = *_tokens;
+	expand.context = context;
 	while (tokens)
 	{
         temp = tokens->data;
@@ -110,7 +104,8 @@ t_token	*expand_tokens(t_token **_tokens, t_context *context)
 			flg_heredoc = true;
 			set_flg_heredoc_expand(tokens->next, context);
 		}
-		tokens->data = expand_token(tokens->data, flg_heredoc, context);
+		expand.token = tokens->data;
+		tokens->data = expand_token(expand, flg_heredoc);
         free(temp);
 		tokens = tokens->next;
 	}

--- a/srcs/expand_tokens.c
+++ b/srcs/expand_tokens.c
@@ -25,10 +25,11 @@ static size_t	delete_single_quote(char **result, char *token)
 	return (i + 1);
 }
 
-static size_t	expand_double_quote(char **result, t_expand expand, bool flg_heredoc)
+static size_t	expand_double_quote(char **result, t_expand expand,
+		bool flg_heredoc)
 {
 	int	i;
-	int		start;
+	int	start;
 
 	i = 1;
 	start = 1;
@@ -36,7 +37,8 @@ static size_t	expand_double_quote(char **result, t_expand expand, bool flg_hered
 	{
 		if (is_expand(expand.token, i) && !flg_heredoc)
 		{
-			*result = free_strjoin(*result, ft_substr(expand.token, start, i - start));
+			*result = free_strjoin(*result, ft_substr(expand.token, start,
+						i - start));
 			i += insert_env(result, &expand.token[i], expand.context);
 			// 「"」と「$」のため、i+1
 			start = i + 1;
@@ -74,7 +76,8 @@ static char	*expand_token(t_expand expand, bool flg_heredoc)
 		else
 		{
 			if (is_quote(expand.token[i++]))
-				result = free_strjoin(result, ft_substr(expand.token, start, i - start));
+				result = free_strjoin(result, ft_substr(expand.token, start,
+							i - start));
 			// 変数展開したときのみ、start を更新したいため、continue する
 			continue ;
 		}
@@ -86,11 +89,11 @@ static char	*expand_token(t_expand expand, bool flg_heredoc)
 
 t_token	*expand_tokens(t_token **_tokens, t_context *context)
 {
-	t_token	*head;
-	t_token	*tokens;
-    char    *temp;
-	bool	flg_heredoc;
-	t_expand expand;
+	t_token		*head;
+	t_token		*tokens;
+	char		*temp;
+	bool		flg_heredoc;
+	t_expand	expand;
 
 	flg_heredoc = false;
 	head = *_tokens;
@@ -98,7 +101,7 @@ t_token	*expand_tokens(t_token **_tokens, t_context *context)
 	expand.context = context;
 	while (tokens)
 	{
-        temp = tokens->data;
+		temp = tokens->data;
 		if (is_heredoc(tokens->data))
 		{
 			flg_heredoc = true;
@@ -106,9 +109,8 @@ t_token	*expand_tokens(t_token **_tokens, t_context *context)
 		}
 		expand.token = tokens->data;
 		tokens->data = expand_token(expand, flg_heredoc);
-        free(temp);
+		free(temp);
 		tokens = tokens->next;
 	}
 	return (head);
 }
-

--- a/srcs/expand_utils.c
+++ b/srcs/expand_utils.c
@@ -14,7 +14,8 @@
 
 void	set_flg_heredoc_expand(t_token *token, t_context *context)
 {
-	if (ft_strchr(token->data, SINGLE_QUOTE) != NULL || ft_strchr(token->data, DOUBLE_QUOTE) != NULL)
+	if (ft_strchr(token->data, SINGLE_QUOTE) != NULL
+		|| ft_strchr(token->data, DOUBLE_QUOTE) != NULL)
 		context->flg_heredoc_expand = false;
 }
 
@@ -25,8 +26,8 @@ bool	is_expand(char *token, int i)
 
 char	*search_env(const char *key, t_kvs *environ)
 {
-	int	i;
-	char *result;
+	int		i;
+	char	*result;
 
 	i = 0;
 	result = NULL;
@@ -48,8 +49,7 @@ size_t	count_key_len(char *token)
 	size_t	i;
 
 	i = 0;
-	while ((ft_isalnum(token[i]) || token[i] == '_')
-		&& token[i])
+	while ((ft_isalnum(token[i]) || token[i] == '_') && token[i])
 		i++;
 	return (i);
 }
@@ -58,8 +58,8 @@ size_t	insert_env(char **buffer, char *token, t_context *context)
 {
 	size_t	key_len;
 	char	*value;
-    char *substr;
-	int	i;
+	char	*substr;
+	int		i;
 
 	i = 0;
 	key_len = 0;
@@ -80,4 +80,3 @@ size_t	insert_env(char **buffer, char *token, t_context *context)
 	*buffer = free_strjoin(*buffer, value);
 	return (key_len);
 }
-

--- a/srcs/expand_utils.c
+++ b/srcs/expand_utils.c
@@ -12,6 +12,12 @@
 
 #include "minishell.h"
 
+void	set_flg_heredoc_expand(t_token *token, t_context *context)
+{
+	if (ft_strchr(token->data, SINGLE_QUOTE) != NULL || ft_strchr(token->data, DOUBLE_QUOTE) != NULL)
+		context->flg_heredoc_expand = false;
+}
+
 bool	is_expand(char *token, int i)
 {
 	return (token[i] == '$' && !(token[i + 1] == '\0' || token[i + 1] == '$'));

--- a/srcs/heredoc.c
+++ b/srcs/heredoc.c
@@ -121,3 +121,4 @@ bool	process_heredoc(t_node *parsed_tokens, t_context *context)
 	}
 	return (EXIT_SUCCESS);
 }
+

--- a/srcs/heredoc.c
+++ b/srcs/heredoc.c
@@ -121,4 +121,3 @@ bool	process_heredoc(t_node *parsed_tokens, t_context *context)
 	}
 	return (EXIT_SUCCESS);
 }
-

--- a/srcs/heredoc_utils.c
+++ b/srcs/heredoc_utils.c
@@ -24,20 +24,23 @@ char *expand_heredoc(char **line, t_context *context)
 	size_t	i;
 	int		start;
 	char *result;
+	t_expand expand;
 
+	expand.context = context;
+	expand.token = *line;
 	i = 0;
 	start = 0;
 	result = ft_strdup("");
-	while ((*line)[i])
+	while (expand.token[i])
 	{
-		if ((*line)[i] == '$')
+		if (expand.token[i] == '$')
 		{
-			i = expand_variable(&result, *line, context, start, i);
+			i = expand_variable(&result, expand, start, i);
 			start = i;
 		}
 		else
 			i++;
 	}
-	free(*line);
+	free(expand.token);
 	return (result);
 }


### PR DESCRIPTION
- t_expnad 型を使用する形に修正
- set_flg_heredoc_expand を utils に移動
- コメントがあるため、26 行の関数があるが、ほかは大丈夫なはず。
    - コメントは最後にまとめて削除