### PR TITLE
ヒアドキュメント中の SIGINT を修正

### DIFF
--- a/includes/units/invoke_commands.h
+++ b/includes/units/invoke_commands.h
@@ -79,5 +79,6 @@ bool		is_builtin(const t_node *parsed_tokens);
 bool		is_heredoc(char *argv);
 bool		process_heredoc(t_node *parsed_tokens, t_context *context);
 char		*expand_heredoc(char **line, t_context *context);
+int			here_document_rl_event_hook(void);
 
 #endif

--- a/srcs/heredoc.c
+++ b/srcs/heredoc.c
@@ -24,6 +24,9 @@ static void	heredoc_child_process(char *delimiter, int fds[2],
 	while (true)
 	{
 		line = readline("> ");
+		if (line == NULL)
+			ft_printf("minishell: warning: here-document at line 1 delimited by end-of-file (wanted `%s')\n",
+				delimiter);
 		if (g_sig == SIGINT)
 		{
 			rl_done = 0;
@@ -80,7 +83,8 @@ static bool	setup_heredoc(t_node *parsed_tokens, int i, t_context *context)
 			EXIT_FAILURE);
 	if (pid == 0)
 		heredoc_child_process(parsed_tokens->argv[i + 1], fds, context);
-	if (heredoc_parent_process(parsed_tokens, fds, pid, context) == EXIT_FAILURE)
+	if (heredoc_parent_process(parsed_tokens, fds, pid,
+			context) == EXIT_FAILURE)
 		return (EXIT_FAILURE);
 	return (EXIT_SUCCESS);
 }

--- a/srcs/heredoc.c
+++ b/srcs/heredoc.c
@@ -37,7 +37,7 @@ static void	heredoc_child_process(char *delimiter, int fds[2],
 			wrap_close(fds[OUT]);
 			free(line);
 			free_environ(context);
-			exit(EXIT_FAILURE);
+			exit(EXIT_STATUS_INVALID + SIGINT);
 		}
 		if (ft_strncmp(delimiter, line, ft_strlen(delimiter) + 1) == 0)
 			break ;
@@ -60,6 +60,7 @@ static bool	heredoc_parent_process(t_node *parsed_tokens, int fds[2], pid_t pid,
 	waitpid(pid, &status, 0);
 	if (WIFSIGNALED(status) == EXIT_SUCCESS)
 	{
+		catch_exit_status(context, status);
 		wrap_close(fds[IN]);
 		wrap_close(fds[OUT]);
 		return (false);

--- a/srcs/heredoc_utils.c
+++ b/srcs/heredoc_utils.c
@@ -12,6 +12,13 @@
 
 #include "minishell.h"
 
+int	here_document_rl_event_hook(void)
+{
+	if (g_sig == SIGINT)
+		rl_done = 1;
+	return (EXIT_SUCCESS);
+}
+
 bool	is_heredoc(char *argv)
 {
 	if (ft_strncmp(argv, "<<", 3) == 0)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -59,6 +59,7 @@ void	shell_loop(t_context *context)
 	line = NULL;
 	while (true)
 	{
+		g_sig = 0;
 		parent_signal_setting();
 		line = readline("minishell$ ");
 		setting_status(context);


### PR DESCRIPTION
- 子プロセスを exit で終了させてる都合上、WIFSIGNALED で判定できないため、WEXITSTATUS でエミュレート
- is 系以外は EXIT_FAILURE, EXIT_SUCCESS で統一したいので、そちらにしちゃいました！