### PR TITLE
cat << EOF | grep a が実行できない不具合を修正

### DIFF
--- a/srcs/execute.c
+++ b/srcs/execute.c
@@ -52,8 +52,13 @@ int	child_process(t_node *parsed_tokens, t_exe_info *info, char **path_list,
 	// STDOUT → current_pipefd[OUT]
 	if (info->exec_count < info->pipe_num)
 	{
+		if (parsed_tokens->fds[IN] != INVALID_FD)
+		{
+			wrap_dup2(parsed_tokens->fds[IN], STDIN_FILENO);
+			close_redirect_fd(&parsed_tokens->fds[IN]);
+		}
 		wrap_dup2(parsed_tokens->fds[OUT], STDOUT_FILENO);
-		double_close_fd(&parsed_tokens->fds[OUT], &parsed_tokens->fds[IN]);
+		close_redirect_fd(&parsed_tokens->fds[OUT]);
 	}
 	// 初めのコマンド以外は、入力を前のpipefd[IN]にリダイレクトする
 	// STDIN → before_pipe_fd[IN]

--- a/srcs/invoke_commands.c
+++ b/srcs/invoke_commands.c
@@ -62,6 +62,7 @@ static int	exec_pipe(t_node *parsed_tokens, t_exe_info *info, char **path_list,
 			parsed_tokens->fds[IN] = saved_fd;
 		child_process(parsed_tokens, info, path_list, context);
 	}
+	wrap_close(saved_fd);
 	parent_process(parsed_tokens, info);
 	info->exec_count++;
 	return (EXIT_SUCCESS);

--- a/srcs/invoke_commands.c
+++ b/srcs/invoke_commands.c
@@ -76,7 +76,7 @@ static int	exec_last_pipe_cmd(t_node *parsed_tokens, t_exe_info *info,
 	if (info->pid[info->exec_count] == 0)
 	{
 		wrap_dup2(info->before_cmd_fd, STDIN_FILENO);
-		wrap_close(info->before_cmd_fd);
+		close_redirect_fd(&info->before_cmd_fd);
 		execute(parsed_tokens, path_list, context, info);
 		exit(EXIT_FAILURE);
 	}
@@ -92,7 +92,8 @@ static int	exec_last_pipe_cmd(t_node *parsed_tokens, t_exe_info *info,
 static int	exec_cmd(t_node *parsed_tokens, char **path_list,
 		t_context *context, t_exe_info *info)
 {
-	if (process_heredoc(parsed_tokens, path_list, context, info) == EXIT_FAILURE)
+	if (process_heredoc(parsed_tokens, path_list, context,
+			info) == EXIT_FAILURE)
 		return (EXIT_FAILURE);
 	if (parsed_tokens->next == NULL && parsed_tokens->argv != NULL)
 		return (exec_single_cmd(parsed_tokens, path_list, context, info));

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -44,6 +44,7 @@ bool	preprocess_line(char *line, t_context *context, t_token **tokens)
 	*tokens = tokenization(line);
 	if (check_syntax(*tokens, context) == EXIT_FAILURE)
 	{
+		add_history(line);
 		free_tokens(tokens);
 		return (EXIT_SUCCESS);
 	}


### PR DESCRIPTION
- シンタックスエラーでも history に追加