### PR TITLE
パイプがあるときの終了ステータスを調整

### DIFF
--- a/srcs/invoke_commands.c
+++ b/srcs/invoke_commands.c
@@ -71,6 +71,8 @@ static int	exec_pipe(t_node *parsed_tokens, t_exe_info *info, char **path_list,
 static int	exec_last_pipe_cmd(t_node *parsed_tokens, t_exe_info *info,
 		char **path_list, t_context *context)
 {
+	int	status;
+
 	info->pid[info->exec_count] = fork();
 	if (info->pid[info->exec_count] == -1)
 		return (ft_printf("error\n"), EXIT_FAILURE);
@@ -84,7 +86,8 @@ static int	exec_last_pipe_cmd(t_node *parsed_tokens, t_exe_info *info,
 	close_redirect_fd(&info->before_cmd_fd);
 	while (info->exec_count >= 0)
 	{
-		waitpid(info->pid[info->exec_count], NULL, 0);
+		waitpid(info->pid[info->exec_count], &status, 0);
+		catch_exit_status(context, status);
 		info->exec_count--;
 	}
 	return (EXIT_SUCCESS);


### PR DESCRIPTION
パイプのときの終了ステータス受け取ってないだけでした。  
```
minishell$ cat | cat
^C
minishell$ expr $? + $?
260
```